### PR TITLE
Stop contact button spam

### DIFF
--- a/src/assets/js/submissionForm.js
+++ b/src/assets/js/submissionForm.js
@@ -19,6 +19,7 @@ let redirecting = false
 
 document.getElementById('submission-form').addEventListener('submit', async function(event) {
   event.preventDefault();
+  buttonDisabled(true)
   const formData = new FormData(event.target);
   const data = {
     name: formData.get('name').trim(),
@@ -51,6 +52,7 @@ document.getElementById('submission-form').addEventListener('submit', async func
         event.target.reset();
       } else {
         updateNotice(submissionData)
+        buttonDisabled(false)
       }
       await sendDiscordNot(data, submissionData)
 
@@ -58,6 +60,7 @@ document.getElementById('submission-form').addEventListener('submit', async func
       console.error('Error:', error);
     }
   }
+  buttonDisabled(false)
 });
 
 function updateNotice(data) {
@@ -66,6 +69,10 @@ function updateNotice(data) {
   newError.className = 'errorDiv';
   newError.innerHTML = `<span class="errorX">X</span> <span class="errorText">${data.reason}</span>`
   errorDiv.appendChild(newError);
+}
+
+function buttonDisabled(boolean) {
+  document.querySelector('.contact-button').disabled = boolean
 }
 
 async function sendDiscordNot(formContent, submissionData) {

--- a/src/content/contact.md
+++ b/src/content/contact.md
@@ -41,7 +41,7 @@ updated: "2025-9-25"
     </label>
   </div>
 
-  <div><button type="submit" id="form">Send Message</button></div>
+  <div><button class="contact-button" type="submit" id="form">Send Message</button></div>
   <div ><ul class="errors"></ul></div>
 </form>
 


### PR DESCRIPTION
Disable button on click and only enable when needed to stop submission spam or users clicking numerous times thinking it didn't send.